### PR TITLE
Force a new DB read for meta data when getting order data

### DIFF
--- a/src/SwedbankPay/Core/Adapter/WC_Adapter.php
+++ b/src/SwedbankPay/Core/Adapter/WC_Adapter.php
@@ -166,6 +166,8 @@ class WC_Adapter extends PaymentAdapter implements PaymentAdapterInterface
     public function getOrderData($order_id)
     {
         $order = wc_get_order($order_id);
+	// Force a new DB read (and update cache) for meta data.
+	$order->read_meta_data(true);
 
         $countries = WC()->countries->countries;
         $states = WC()->countries->states;


### PR DESCRIPTION
Makes sure that the latest meta data is used when using an external object cache.

Related: https://github.com/SwedbankPay/swedbank-pay-woocommerce-payments/issues/41 https://github.com/SwedbankPay/swedbank-pay-woocommerce-core/pull/14